### PR TITLE
Add automation to regenerate themes if necessary

### DIFF
--- a/.github/workflows/refresh-pipenv.yml
+++ b/.github/workflows/refresh-pipenv.yml
@@ -1,0 +1,29 @@
+---
+
+name: Refresh Pipenv on schedule
+
+on: 
+  schedule:
+    - cron: "45 23 * * 0"
+
+jobs:
+  pipenv-refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Python and cache pip
+        uses: actions/setup-python@v4
+        with:
+            cache: "pip"
+      - name: Install pipenv
+        run: python -m pip install --upgrade pipenv
+      - name: Regenerate Pipfile.lock
+        run: pipenv update
+      - name: Commit and push changes in Pipfile.lock
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add Pipfile.lock
+          git commit -m "Update Pipfile.lock via gh-actions"
+          git push

--- a/.github/workflows/refresh-pipenv.yml
+++ b/.github/workflows/refresh-pipenv.yml
@@ -25,5 +25,5 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add Pipfile.lock
-          git commit -m "Update Pipfile.lock via gh-actions"
+          git diff-index --cached --quiet HEAD || git commit -m "Update Pipfile.lock via gh-actions"
           git push

--- a/.github/workflows/regenerate-themes.yml
+++ b/.github/workflows/regenerate-themes.yml
@@ -1,0 +1,47 @@
+---
+
+name: Regenerate theme files
+
+on: 
+  push:
+    branches:
+      - main
+    paths:
+      - Pipfile.lock
+
+jobs:
+  theme-regenerate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Python and cache pipenv
+        uses: actions/setup-python@v4
+        with:
+            cache: "pipenv"
+      - name: Install pipenv
+        run: python -m pip install --upgrade pipenv
+      - name: Setup pipenv for project
+        run: pipenv sync
+      - name: Generate CSS files
+        run: pipenv run ./src/generate-css.sh
+      - name: Configure git for github-actions as author
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Commit changes in theme css
+        run: |
+          git add css/themes
+          git diff-index --cached --quiet HEAD || git commit -m "Update theme css via gh-actions"
+      - name: Generate SCSS files
+        run: pipenv run ./src/generate.py
+      - name: Commit changes in theme scss mixins
+        run: |
+          git add dist/themes
+          git diff-index --cached --quiet HEAD || git commit -m "Update theme scss mixins via gh-actions"
+      - name: Commit changes in scss highlight and helper files
+        run: |
+          git add dist/*.scss
+          git diff-index --cached --quiet HEAD || git commit -m "Update scss highlight & helper via gh-actions"
+      - name: Push all changes made via gh-actions
+        run: git push

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ There are currently not compatible thirdparty packages that have been excluded.
 
 ## Automatic archive updates
 
-It is the intention that the archive of CSS and CSS variables files will be updated either on a schedule or after package updates.
-If there is a useful way maybe even a npm package could be created.
-TBD
+Currently there is a workflow set up that will run each sunday to check if the `Pipfile.lock` got updated.
+If there are changes those get commited and pushed.
+This triggers another workflow that regenerates all theme and related files.
 
 ## Future
 


### PR DESCRIPTION
This adds two workflows.

The first runs on a schedule each Sunday to check if there are changes to the `Pipfile.lock` which should indicate a change in the themes.
The only time no changes in themes happen if either `cssutils` gets and update or `pygments` is updated without changes to the builtin themes.
The workflow automatically commits and pushes a change in the `Pipfile.lock`.

The second will run on pushes to `main` that change the `Pipfile.lock` and runs all scripts to (re)generate the theme and related files.
This should be triggered by the scheduled workflow but also by manual pushes.
If the manual push also includes the updated files or if they have been added prior the workflow should run without committing and pushing changes.